### PR TITLE
Update http gem from deprecated fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+## 1.0.0 - 01/28/2019
+  * Allow newer http gem dependency (#3)
+  * Drop support for Ruby 2.2 and earlier
+
+## 0.3.0 - 09/21/2017
+  * Allow doing auth over body params, instead of basic auth (header) (#1)
+
+## 0.2.1 - 04/18/2017
+  * Fix issue JWT with nbf claim one second in the past
+
+## 0.2.0 - 04/14/2017
+  * Update README with list of cache backends
+  * Fix manager delegate for client attrs
+  * Add support for default_scope
+  * Fix manager call to cache layer
+  * Don't cache with nil key
+  * Fix RefreshToken and ResourceOwnerCredentials initializer
+  * Only cache token when key is not nil
+  * Return nil from cached, not false
+  * Add exp leeway to cache expiration
+  * Dynamically define methods for OAuth2c::Client
+  * Define respond_to_missing? for OAuth2::Cache::Manager
+  * Allow three legged token method to receive hash with params
+  * Allow expires_at to be set on access token
+  * Add expired? with leeway support to AccessToken
+  * Define comparison operator for AccessToken to return false for other class
+  * Properly convert time for access token to handle serialization
+
+
+## 0.1.0 - 03/10/2017
+  * Initial release

--- a/lib/oauth2c/version.rb
+++ b/lib/oauth2c/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module OAuth2c
-  VERSION = "0.3.0"
+  VERSION = '1.0.0.beta1'.freeze
 end

--- a/lib/oauth2c/version.rb
+++ b/lib/oauth2c/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module OAuth2c
-  VERSION = '1.0.0.beta1'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/oauth2c.gemspec
+++ b/oauth2c.gemspec
@@ -47,8 +47,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "http"
-  spec.add_runtime_dependency "jwt"
+  spec.add_runtime_dependency "http", "~> 4"
+  spec.add_runtime_dependency "jwt", "~> 1.5"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"

--- a/oauth2c.gemspec
+++ b/oauth2c.gemspec
@@ -37,6 +37,8 @@ Gem::Specification.new do |spec|
   #     "public gem pushes."
   # end
 
+  spec.required_ruby_version = ">= 2.3.0"
+
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
@@ -45,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "http", "~> 2.0"
+  spec.add_runtime_dependency "http", "~> 4.0"
   spec.add_runtime_dependency "jwt", "~> 1.5"
 
   spec.add_development_dependency "bundler", "~> 1.14"
@@ -54,5 +56,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "redis", "~> 3.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 2.0"
+  spec.add_development_dependency "webmock", "~> 3.0"
 end

--- a/oauth2c.gemspec
+++ b/oauth2c.gemspec
@@ -21,8 +21,8 @@ require 'oauth2c/version'
 Gem::Specification.new do |spec|
   spec.name          = "oauth2c"
   spec.version       = OAuth2c::VERSION
-  spec.authors       = ["Rodrigo Kochenburger"]
-  spec.email         = ["divoxx@gmail.com"]
+  spec.authors       = ["Doximity"]
+  spec.email         = ["engineering@doximity.com"]
 
   spec.summary       = %q{OAuth2c is a extensible OAuth2 client implementation}
   spec.description   = %q{OAuth2c is a extensible OAuth2 client implementation}
@@ -47,14 +47,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "http", "~> 4.0"
-  spec.add_runtime_dependency "jwt", "~> 1.5"
+  spec.add_runtime_dependency "http"
+  spec.add_runtime_dependency "jwt"
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "byebug"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "redis", "~> 3.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 3.0"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "redis"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "webmock"
 end


### PR DESCRIPTION
oauth2c had required http ~> 2.0, which is holding back our ability to update the http gem in projects that use oauth2c.

This will be is a breaking change for anyone using this gem with ruby <= 2.2, which http 4.x has dropped support for. There appear to be no other breaking changes.

I'm proposing bumping the version to 1.x since we've been using this stably in production for a long time now and because a major bump is appropriate for a potentially breaking
change.

I'll test this branch of auth2c in our projects before final release.
